### PR TITLE
Enforce updating winget to a known version

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -146,8 +146,8 @@ function modernizeWinPowerShell {
 
 function ensureWinGet {
     if (Get-Command "winget.exe" -ErrorAction SilentlyContinue) {
-        Write-Host "winget already installed."
-        return
+        Write-Host "winget already installed, found: $(& winget -v)."
+        Get-AppxPackage -Name Microsoft.DesktopAppInstaller | Remove-AppxPackage
     }
     if ($PSVersionTable.PSEdition -ne "Desktop") {
         Write-Host "Installing winget requires Desktop PowerShell, aborting."


### PR DESCRIPTION
e.g. Azure DevBox have winget in an old version 1.2