### PR TITLE
use LinuxBrew for Ubuntu 22 under WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ irm 'https://raw.githubusercontent.com/davidjenni/dotfiles/main/bootstrap.ps1' |
 to bootstrap, run this in a default Terminal.app prompt:
 
 ````shell
-    curl -fsSL https://github.com/davidjenni/dotfiles/raw/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/davidjenni/dotfiles/main/bootstrap.sh | bash
 ````
 
 ### Linux (Ubuntu/Debian)
@@ -29,5 +29,5 @@ still missing apps!
 * open terminal/WSL:
 
 ````shell
-    curl -fsSL https://github.com/davidjenni/dotfiles/raw/master/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/davidjenni/dotfiles/main/bootstrap.sh | bash
 ````

--- a/bash/bash_aliases
+++ b/bash/bash_aliases
@@ -58,3 +58,16 @@ fi
 if have zoxide; then
   eval "$(zoxide init bash)"
 fi
+
+case $- in
+  *i*)  # interactive
+    if `shopt -q login_shell`; then
+      if have neofetch; then
+        neofetch
+      else
+        echo " $(uname -a)"
+        uptime
+      fi
+    fi
+  ;;
+esac

--- a/bash/bash_aliases
+++ b/bash/bash_aliases
@@ -23,3 +23,16 @@ if uname -r | grep -q "WSL"; then
   alias ssh='ssh.exe'
   alias ssh-add='ssh-add.exe'
 fi
+
+case `uname` in
+  'Darwin')
+    if [ -d "/opt/homebrew/bin" ] ; then
+      eval "$(/opt/homebrew/bin/brew shellenv)" ;;
+    fi
+    ;;
+  'Linux')
+    if [ -d "home/linuxbrew/.linuxbrew/bin" ] ; then
+      eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" ;;
+    fi
+    ;;
+esac

--- a/bash/bash_aliases
+++ b/bash/bash_aliases
@@ -1,9 +1,24 @@
-alias cls='clear'
-alias la='ls -AGF'
-alias ls='ls -GF'
-alias ll='ls -lGF'
+function have {
+  hash "$1" >&/dev/null
+}
 
-alias l='less'
+alias cls='clear'
+if have lsd; then
+  alias la='lsd -a --group-directories-first'
+  alias ls='lsd --group-directories-first'
+  alias ll='lsd -l --group-directories-first'
+else
+  alias la='ls -aGF'
+  alias ls='ls -GF'
+  alias ll='ls -lGF'
+fi
+
+if have bat; then
+  alias l='bat'
+else
+  alias l='less'
+fi
+
 export LESS="-c -i -x4 -J -w -M -r"
 export VISUAL='nvim'
 alias v='nvim'
@@ -27,12 +42,19 @@ fi
 case `uname` in
   'Darwin')
     if [ -d "/opt/homebrew/bin" ] ; then
-      eval "$(/opt/homebrew/bin/brew shellenv)" ;;
+      eval "$(/opt/homebrew/bin/brew shellenv)"
     fi
     ;;
   'Linux')
-    if [ -d "home/linuxbrew/.linuxbrew/bin" ] ; then
-      eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" ;;
+    if [ -d "/home/linuxbrew/.linuxbrew/bin" ] ; then
+      eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
     fi
     ;;
 esac
+
+if have starship; then
+  eval "$(starship init bash)"
+fi
+if have zoxide; then
+  eval "$(zoxide init bash)"
+fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,6 +4,7 @@
 
 originGitHub='https://github.com/davidjenni/dotfiles.git'
 dotPath=$HOME/dotfiles
+scriptDir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 shopt -s nocasematch
 
@@ -158,7 +159,7 @@ function copyFile {
   fi
   targetDir=$(dirname $target)
   mkdir -p $targetDir
-  sourceFile=$dotPath/$sourceRelPath
+  sourceFile=$scriptDir/$sourceRelPath
   echo "  $sourceFile -> $target"
   cp $sourceFile $target
 }
@@ -171,7 +172,7 @@ function copyDir {
     rm -rf $targetDir >&/dev/null
   fi
   mkdir -p $targetDir
-  sourceDir=$dotPath/$sourceRelPath
+  sourceDir=$scriptDir/$sourceRelPath
   echo "  $sourceDir -> $targetDir"
   cp -R $sourceDir/* $targetDir
 }
@@ -179,7 +180,7 @@ function copyDir {
 function setupShellEnv {
   echo "Setting up shell environment..."
   ensureGitNames noprompt
-  writeGitConfig $dotPath/gitconfig.ini
+  writeGitConfig $scriptDir/gitconfig.ini
 
   local configDir=$HOME/.config
   if [ ! -d "$configDir" ] ; then
@@ -290,5 +291,5 @@ main() {
   echo "Done."
 }
 
-echo "Starting bootstrap.sh..."
+echo "Starting bootstrap.sh (in $scriptDir with working dir: $(pwd))..."
 main $*

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -121,7 +121,7 @@ function installApps {
     tmux
     tre-command
     tokei
-    wget
+    zoxide
     xz
     )
 
@@ -146,7 +146,7 @@ function installApps {
       brew install --cask $_casks
     ;;
   esac
-  exit $?
+  return $?
 }
 
 function copyFile {

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -10,13 +10,15 @@ set fish_greeting ""
 
 switch (uname)
     case Linux
+        if test -d /home/linuxbrew/.linuxbrew/bin
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        end
         if test -x /usr/bin/lesspipe.sh
             set -x LESSOPEN "|lesspipe.sh %s"
         end
     case Darwin
         if test -d /opt/homebrew/bin
-            fish_add_path /opt/homebrew/bin
-            set -g fish_user_paths "(brew --prefix)/bin" $fish_user_paths
+            eval "$(brew shellenv)"
             if test -x (brew --prefix)/bin/lesspipe.sh
                 set -x LESSOPEN "|lesspipe.sh %s"
             end


### PR DESCRIPTION
on board Ubuntu & Debian apt pkg manager has mostly hopelessly old packages for e.g. neovim etc.

Use [HomeBrew](https://brew.sh]'s linux flavor of `brew` instead. Benefit: single list of packages for both macOS and linux