### PR TITLE
prettify tmux with catppucin

### DIFF
--- a/bash/tmux.conf
+++ b/bash/tmux.conf
@@ -2,11 +2,6 @@ set -g prefix C-a
 set -g base-index 1
 setw -g pane-base-index 1
 
-# colors:
-set -g default-terminal "screen-256color"
-set -g status-bg colour235
-set -g status-fg colour244
-
 # easier split mnemonics:
 bind | split-window -h
 bind - split-window -v
@@ -21,11 +16,46 @@ bind H resize-pane -L 5
 bind J resize-pane -D 5
 bind K resize-pane -U 5
 bind L resize-pane -R 5
+set -g mouse on
 
 # vim mode keys for copy/buffer motions
 setw -g mode-keys vi
 unbind p
 bind p paste-buffer
-bind -t vi-copy 'v' begin-selection
-bind -t vi-copy 'y' copy-selection
+
+unbind r
+bind r source-file ~/.tmux.conf \; display "Reloaded!"
+
+set-option -g status-position top
+
+set -g @catppuccin_window_left_separator ""
+set -g @catppuccin_window_right_separator " "
+set -g @catppuccin_window_middle_separator " █"
+set -g @catppuccin_window_number_position "right"
+
+set -g @catppuccin_window_default_fill "number"
+set -g @catppuccin_window_default_text "#W"
+
+set -g @catppuccin_window_current_fill "number"
+set -g @catppuccin_window_current_text "#W"
+
+set -g @catppuccin_status_modules_right "directory user host session"
+set -g @catppuccin_status_left_separator  " "
+set -g @catppuccin_status_right_separator ""
+set -g @catppuccin_status_right_separator_inverse "no"
+set -g @catppuccin_status_fill "icon"
+set -g @catppuccin_status_connect_separator "no"
+
+set -g @catppuccin_directory_text "#{pane_current_path}"
+
+set -g @plugin 'catppuccin/tmux'
+
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+
+if "test ! -d ~/.tmux/plugins/tpm" \
+   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
+
+# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+run '~/.tmux/plugins/tpm/tpm'
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -72,7 +72,8 @@ function initBrew {
 function ensureBrew {
   if have brew; then
     echo "$(brew --version) is installed"
-    brew update
+    # skip update for now, causes errors in CI:
+    # brew update
     return
   fi
   case `uname` in


### PR DESCRIPTION
workaround for #37: skipping `brew update` to avoid also updating other installed apps on CI runners (e.g. php which promptly fails)
