### PR TITLE
fix hidden breaking change in starship 1.24.2

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -68,8 +68,6 @@ if command -s starship > /dev/null
         starship module time
     end
     starship init fish | source
-    # contents of enable_trancience function, which is not callable yet after above source
-    bind --user \r transient_execute
-    bind --user -M insert \r transient_execute
+    enable_transience
 end
 


### PR DESCRIPTION
function transient_execute was renamed, see also https://starship.rs/advanced-config/#transientprompt-and-transientrightprompt-in-fish and https://github.com/starship/starship/pull/7015/changes